### PR TITLE
Enable for WC 2.1 beta

### DIFF
--- a/wc-sharedaddy-integration.php
+++ b/wc-sharedaddy-integration.php
@@ -12,7 +12,7 @@ Version: 1.0
 function wc_sharedaddy_add_integration( $integrations ) {
     global $woocommerce;
 
-    if ( is_object( $woocommerce ) && version_compare( $woocommerce->version, '2.1', '>=' ) ) {
+    if ( is_object( $woocommerce ) && version_compare( $woocommerce->version, '2.1-beta-1', '>=' ) ) {
         if ( class_exists('jetpack') ) {
             include_once( 'includes/class-wc-sharedaddy-integration.php' );
             $integrations[] = 'WC_ShareDaddy';


### PR DESCRIPTION
Changing the version_compare parameters in order to test this integration on pre-release versions of WooCommerce 2.1
